### PR TITLE
Fixes for `jest.setMock does not work with jest.dontMock`

### DIFF
--- a/examples/manual_mocks/FileSummarizer-FileSystem.js
+++ b/examples/manual_mocks/FileSummarizer-FileSystem.js
@@ -1,0 +1,13 @@
+var fs = require('FileSystem');
+
+function summarizeFilesInDirectorySync(directoryPath) {
+  return fs.readdirSync(directoryPath).map(function(fileName) {
+    return {
+      fileName: fileName,
+      directory: directoryPath
+    };
+  });
+  return directoryFileSummary;
+}
+
+exports.summarizeFilesInDirectorySync = summarizeFilesInDirectorySync;

--- a/examples/manual_mocks/FileSystem.js
+++ b/examples/manual_mocks/FileSystem.js
@@ -1,0 +1,1 @@
+module.exports = require('fs');

--- a/examples/manual_mocks/__tests__/FileSummarizer-setMock-test.js
+++ b/examples/manual_mocks/__tests__/FileSummarizer-setMock-test.js
@@ -1,0 +1,30 @@
+jest.dontMock('FileSummarizer-FileSystem');
+jest.setMock('FileSystem', {readdirSync: jest.genMockFn()});
+
+describe('FileSummarizer-FileSystem', function() {
+  describe('listFilesInDirectorySync', function() {
+    var MOCK_FILE_INFO = {
+      '/path/to/file1.js':
+        'console.log("file1 contents");',
+
+      '/path/to/file2.txt':
+        "file2 contents"
+    };
+
+    beforeEach(function() {
+      // Set up some mocked out file info before each test
+
+      require('FileSystem').readdirSync.mockReturnValue(
+        Object.keys(MOCK_FILE_INFO));
+    });
+
+    it('includes all files in the directory in the summary', function() {
+      var FileSummarizer = require('FileSummarizer-FileSystem');
+      var fileSummary = FileSummarizer.summarizeFilesInDirectorySync(
+        '/path/to'
+      );
+
+      expect(fileSummary.length).toBe(2);
+    });
+  });
+})


### PR DESCRIPTION
To run test, disable config.rootDir in package.json, then execute `NODE_PATH=examples/manual_mocks/ ./bin/jest.js examples/manual_mocks/__tests__`

related to https://github.com/facebook/jest/issues/230